### PR TITLE
Change TS Node to peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A TypeScript plugin for db-migrate.
 Usage is very simple. Simply install this plugin via `npm install db-migrate-plugin-typescript`
 or if using yarn: `yarn add db-migrate-plugin-typescript` 
 
+This plugin has a peer dependency on ts-node as well. So you will need to install that as a dependency or dev-dependency as well, `npm install ts-node` or `yarn add ts-node` if using yarn.
+
 The plugin will automatically resolve and compile any `.ts` files in your migrations directory,
 using your regular `tsconfig.json`
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "A db-migrate plugin to enable TypeScript style migrations.",
   "main": "index.js",
-  "dependencies": {
+  "peerDependencies": {
     "ts-node": "^3.3.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
fix: change to peer dependency
This does not work if the user already has ts-node installed, and the nested ts-node under the plugin can not properly resolve the tsconfig json