### PR TITLE
Make ts-node peer dep more permissive

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A db-migrate plugin to enable TypeScript style migrations.",
   "main": "index.js",
   "peerDependencies": {
-    "ts-node": "^3.3.0"
+    "ts-node": "*"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This package currently requires a version of ts-node that very old. Updating the peer dependency to `*` will give people more control over what version of `ts-node` they want to use.